### PR TITLE
Add env var for data dir

### DIFF
--- a/cmd/expenseowl/main.go
+++ b/cmd/expenseowl/main.go
@@ -34,7 +34,7 @@ var categories = []string{
 
 func runServer() {
 	cfg := config.NewConfig()
-	dataDir := "./data"
+	dataDir := cfg.StoragePath
 	if err := os.MkdirAll(dataDir, 0755); err != nil {
 		log.Fatalf("Failed to create data directory: %v", err)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -69,9 +69,13 @@ func NewConfig() *Config {
 			currency = symbol
 		}
 	}
+	storagePath := "./data" // Default to ./data
+	if envStoragePath := os.Getenv("DATA_DIR"); envStoragePath != "" {
+		storagePath = envStoragePath
+	}
 	return &Config{
 		ServerPort:  "8080",
-		StoragePath: "./data",
+		StoragePath: storagePath,
 		Categories:  categories,
 		Currency:    currency,
 	}


### PR DESCRIPTION
For my little Sandstorm packaging experiment, I'd *prefer* to set the data directory via an environment variable. When experimenting here, I also noticed that even if I changed the value set in the config... it's hardcoded again right after the config is loaded. So in this pull request, I allow the data directory to be overridden with DATA_DIR (the variable name I think is most common for this), and then in the main file I had it pull the data directory from the config.

I am *not* a Go developer, but I think this works and mirrors what you were already doing. Feedback welcome, telling me to take a hike, also acceptable.