### PR TITLE
Fix mistyped 'cpntent-type' and rename misleading request variable

### DIFF
--- a/cmd/expenseowl/main.go
+++ b/cmd/expenseowl/main.go
@@ -137,14 +137,14 @@ func runClient(serverAddr string) {
 		log.Fatalf("Failed to marshal expense data: %v", err)
 	}
 	url := fmt.Sprintf("http://%s/expense", serverAddr)
-	resp, err := http.NewRequest(http.MethodPut, url, bytes.NewBuffer(jsonData))
+	req, err := http.NewRequest(http.MethodPut, url, bytes.NewBuffer(jsonData))
 	if err != nil {
 		log.Fatalf("Failed to create request: %v", err)
 	}
-	resp.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Content-Type", "application/json")
 
 	client := &http.Client{}
-	response, err := client.Do(resp)
+	response, err := client.Do(req)
 	if err != nil {
 		log.Fatalf("Failed to send request: %v", err)
 	}

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -100,7 +100,7 @@ func (h *Handler) ServeTableView(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
-	w.Header().Set("Cpntent-Type", "text/html")
+	w.Header().Set("Content-Type", "text/html")
 	if err := web.ServeTemplate(w, "table.html"); err != nil {
 		http.Error(w, "Failed to serve template", http.StatusInternalServerError)
 		return


### PR DESCRIPTION
**Description:**
This PR corrects a small typo in the Content-Type header and renames a request variable for better clarity.

**Changes:**
- Fixed a mistyped header key: `Cpntent-Type` → `Content-Type`
- Renamed `resp` to `req` to align with standard naming conventions for request variables

No functional changes were introduced.
Let me know if any adjustments are needed. Thanks for reviewing!