### PR TITLE
Fix date assignment for edit expense

### DIFF
--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -109,7 +109,6 @@ func (s *jsonStore) EditExpense(expense *config.Expense) error {
 	found := false
 	for i, exp := range data.Expenses {
 		if exp.ID == expense.ID {
-			expense.Date = exp.Date
 			data.Expenses[i] = expense
 			found = true
 			break


### PR DESCRIPTION
This pull request makes a small change to the `EditExpense` method in `internal/storage/storage.go`. The change removes the line that was overwriting the `Date` field of the `expense` object with the existing value from the data store, ensuring that the `Date` field can now be updated when editing an expense.