### PR TITLE
Added support for zero decimal currencies

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -40,35 +40,35 @@ var defaultCategories = []string{
 	"Income",
 }
 
-var currencySymbols = map[string]string{
-	"usd": "$",    // US Dollar
-	"eur": "€",    // Euro
-	"gbp": "£",    // British Pound
-	"jpy": "¥",    // Japanese Yen
-	"cny": "¥",    // Chinese Yuan
-	"krw": "₩",    // Korean Won
-	"inr": "₹",    // Indian Rupee
-	"rub": "₽",    // Russian Ruble
-	"brl": "R$",   // Brazilian Real
-	"zar": "R",    // South African Rand
-	"aed": "AED",  // UAE Dirham
-	"aud": "A$",   // Australian Dollar
-	"cad": "C$",   // Canadian Dollar
-	"chf": "Fr",   // Swiss Franc
-	"hkd": "HK$",  // Hong Kong Dollar
-	"sgd": "S$",   // Singapore Dollar
-	"thb": "฿",    // Thai Baht
-	"try": "₺",    // Turkish Lira
-	"mxn": "Mex$", // Mexican Peso
-	"php": "₱",    // Philippine Peso
-	"pln": "zł",   // Polish Złoty
-	"sek": "kr",   // Swedish Krona
-	"nzd": "NZ$",  // New Zealand Dollar
-	"dkk": "kr.",  // Danish Krone
-	"idr": "Rp",   // Indonesian Rupiah
-	"ils": "₪",    // Israeli New Shekel
-	"vnd": "₫",    // Vietnamese Dong
-	"myr": "RM",   // Malaysian Ringgit
+var currencies = []string{
+	"usd",    // US Dollar
+	"eur",    // Euro
+	"gbp",    // British Pound
+	"jpy",    // Japanese Yen
+	"cny",    // Chinese Yuan
+	"krw",    // Korean Won
+	"inr",    // Indian Rupee
+	"rub",    // Russian Ruble
+	"brl",   // Brazilian Real
+	"zar",    // South African Rand
+	"aed",  // UAE Dirham
+	"aud",   // Australian Dollar
+	"cad",   // Canadian Dollar
+	"chf",   // Swiss Franc
+	"hkd",  // Hong Kong Dollar
+	"sgd",   // Singapore Dollar
+	"thb",    // Thai Baht
+	"try",    // Turkish Lira
+	"mxn", // Mexican Peso
+	"php",    // Philippine Peso
+	"pln",   // Polish Złoty
+	"sek",   // Swedish Krona
+	"nzd",  // New Zealand Dollar
+	"dkk",  // Danish Krone
+	"idr",   // Indonesian Rupiah
+	"ils",    // Israeli New Shekel
+	"vnd",    // Vietnamese Dong
+	"myr",   // Malaysian Ringgit
 }
 
 type Expense struct {
@@ -77,6 +77,15 @@ type Expense struct {
 	Category string    `json:"category"`
 	Amount   float64   `json:"amount"`
 	Date     time.Time `json:"date"`
+}
+
+func ValidCurrency(item string) bool {
+	for _, s := range currencies {
+		if s == item {
+			return true
+		}
+	}
+	return false
 }
 
 func (e *Expense) Validate() error {
@@ -108,7 +117,7 @@ func NewConfig(dataPath string) *Config {
 		StoragePath: finalPath,
 		Categories:  defaultCategories,
 		StartDate:   1,
-		Currency:    "$", // Default to USD
+		Currency:    "usd", // Default to USD
 	}
 	configPath := filepath.Join(finalPath, "config.json")
 	if _, err := os.Stat(configPath); os.IsNotExist(err) {
@@ -122,8 +131,8 @@ func NewConfig(dataPath string) *Config {
 			log.Println("Using custom categories from environment variables")
 		}
 		if envCurrency := strings.ToLower(os.Getenv("CURRENCY")); envCurrency != "" {
-			if symbol, exists := currencySymbols[envCurrency]; exists {
-				cfg.Currency = symbol
+			if ValidCurrency(envCurrency) {
+				cfg.Currency = envCurrency;
 			}
 			log.Println("Using custom currency from environment variables")
 		}
@@ -183,8 +192,8 @@ func (c *Config) UpdateCategories(categories []string) error {
 
 func (c *Config) UpdateCurrency(currencyCode string) error {
 	c.mu.Lock()
-	if symbol, exists := currencySymbols[strings.ToLower(currencyCode)]; exists {
-		c.Currency = symbol
+	if ValidCurrency(currencyCode) {
+		c.Currency = currencyCode
 	} else {
 		c.mu.Unlock()
 		return errors.New("invalid currency code")

--- a/internal/web/templates/index.html
+++ b/internal/web/templates/index.html
@@ -165,7 +165,6 @@
         function formatCurrency(amount) {
             let formattedAmount = new Intl.NumberFormat('en-US', {minimumFractionDigits: 2, maximumFractionDigits: 2}).format(amount);
 
-
             // check zero decimal currencies
             let zeroDecimalCurrencies = new Set(['jpy', 'vnd', '₫', 'idr']);
             if (zeroDecimalCurrencies.has(currency)) {

--- a/internal/web/templates/index.html
+++ b/internal/web/templates/index.html
@@ -110,7 +110,7 @@
         </div>
     </div>
     <script>
-        let currencySymbol = '$'; // Default to USD
+        let currency = 'usd'; // Default to USD
         let startDate = 1;
         let pieChart = null;
         let currentDate = new Date();
@@ -122,6 +122,38 @@
             '#FFBE0B', '#FF006E', '#8338EC', '#3A86FF', 
             '#FB5607', '#38B000', '#9B5DE5', '#F15BB5'
         ];
+
+        const currencySymbols = {
+            usd: "$",    // US Dollar
+            eur: "€",    // Euro
+            gbp: "£",    // British Pound
+            jpy: "¥",    // Japanese Yen
+            cny: "¥",    // Chinese Yuan
+            krw: "₩",    // Korean Won
+            inr: "₹",    // Indian Rupee
+            rub: "₽",    // Russian Ruble
+            brl: "R$",   // Brazilian Real
+            zar: "R",    // South African Rand
+            aed: "AED",  // UAE Dirham
+            aud: "A$",   // Australian Dollar
+            cad: "C$",   // Canadian Dollar
+            chf: "Fr",   // Swiss Franc
+            hkd: "HK$",  // Hong Kong Dollar
+            sgd: "S$",   // Singapore Dollar
+            thb: "฿",    // Thai Baht
+            try: "₺",    // Turkish Lira
+            mxn: "Mex$", // Mexican Peso
+            php: "₱",    // Philippine Peso
+            pln: "zł",   // Polish Złoty
+            sek: "kr",   // Swedish Krona
+            nzd: "NZ$",  // New Zealand Dollar
+            dkk: "kr.",  // Danish Krone
+            idr: "Rp",   // Indonesian Rupiah
+            ils: "₪",    // Israeli New Shekel
+            vnd: "₫",    // Vietnamese Dong
+            myr: "RM",   // Malaysian Ringgit
+        };
+
         function assignCategoryColors(categories) {
             categories.forEach((category, index) => {
                 if (!categoryColors[category]) {
@@ -132,12 +164,21 @@
 
         function formatCurrency(amount) {
             let formattedAmount = new Intl.NumberFormat('en-US', {minimumFractionDigits: 2, maximumFractionDigits: 2}).format(amount);
-            // Currencies commonly used after the amount
-            const postfixCurrencies = new Set(['kr', 'kr.', 'Fr', 'zł']);
-            if (postfixCurrencies.has(currencySymbol)) {
-                return `${formattedAmount} ${currencySymbol}`;
+
+
+            // check zero decimal currencies
+            let zeroDecimalCurrencies = new Set(['jpy', 'vnd', '₫', 'idr']);
+            if (zeroDecimalCurrencies.has(currency)) {
+                formattedAmount = new Intl.NumberFormat('en-US', {maximumFractionDigits: 0}).format(amount);
             }
-            return `${currencySymbol} ${formattedAmount}`;
+
+            // Currencies commonly used after the amount
+            const postfixCurrencies = new Set(['sek', 'dkk', 'chf', 'pln']);
+            if (postfixCurrencies.has(currency)) {
+                return `${formattedAmount} ${currencySymbols[currency]}`;
+            }
+
+            return `${currencySymbols[currency]} ${formattedAmount}`;
         }
 
         function calculateCategoryBreakdown(expenses) {
@@ -310,7 +351,7 @@
                 categorySelect.innerHTML = config.categories.map(cat => 
                     `<option value="${cat}">${cat}</option>`
                 ).join('');
-                currencySymbol = config.currency;
+                currency = config.currency;
                 startDate = config.startDate;
                 // Fetch expenses
                 const response = await fetch('/expenses');

--- a/internal/web/templates/settings.html
+++ b/internal/web/templates/settings.html
@@ -367,7 +367,6 @@
                 currentCurrency = config.currency;
                 currentStartDate = config.startDate;
 
-
                 renderCategories();
                 populateCurrencySelect();
                 populateStartDateInput();

--- a/internal/web/templates/settings.html
+++ b/internal/web/templates/settings.html
@@ -299,7 +299,7 @@
                 const option = document.createElement('option');
                 option.value = code;
                 option.textContent = `${code.toUpperCase()} (${symbol})`;
-                if (symbol === currentCurrency) {
+                if (code === currentCurrency) {
                     option.selected = true;
                 }
                 select.appendChild(option);
@@ -366,13 +366,8 @@
                 categories = [...config.categories];
                 currentCurrency = config.currency;
                 currentStartDate = config.startDate;
-                let currentCurrencyCode = "usd"; // Default
-                for (const [code, symbol] of Object.entries(currencySymbols)) {
-                    if (symbol === currentCurrency) {
-                        currentCurrencyCode = code;
-                        break;
-                    }
-                }
+
+
                 renderCategories();
                 populateCurrencySelect();
                 populateStartDateInput();

--- a/internal/web/templates/table.html
+++ b/internal/web/templates/table.html
@@ -89,19 +89,58 @@
     </div>
 
     <script>
-        let currencySymbol = '$'; // Default to USD
+        const currencySymbols = {
+            usd: "$",    // US Dollar
+            eur: "€",    // Euro
+            gbp: "£",    // British Pound
+            jpy: "¥",    // Japanese Yen
+            cny: "¥",    // Chinese Yuan
+            krw: "₩",    // Korean Won
+            inr: "₹",    // Indian Rupee
+            rub: "₽",    // Russian Ruble
+            brl: "R$",   // Brazilian Real
+            zar: "R",    // South African Rand
+            aed: "AED",  // UAE Dirham
+            aud: "A$",   // Australian Dollar
+            cad: "C$",   // Canadian Dollar
+            chf: "Fr",   // Swiss Franc
+            hkd: "HK$",  // Hong Kong Dollar
+            sgd: "S$",   // Singapore Dollar
+            thb: "฿",    // Thai Baht
+            try: "₺",    // Turkish Lira
+            mxn: "Mex$", // Mexican Peso
+            php: "₱",    // Philippine Peso
+            pln: "zł",   // Polish Złoty
+            sek: "kr",   // Swedish Krona
+            nzd: "NZ$",  // New Zealand Dollar
+            dkk: "kr.",  // Danish Krone
+            idr: "Rp",   // Indonesian Rupiah
+            ils: "₪",    // Israeli New Shekel
+            vnd: "₫",    // Vietnamese Dong
+            myr: "RM",   // Malaysian Ringgit
+        };
+
+        let currency = 'usd'; // Default to USD
         let currentDate = new Date();
         let allExpenses = [];
         let startDate = 1
 
         function formatCurrency(amount) {
             let formattedAmount = new Intl.NumberFormat('en-US', {minimumFractionDigits: 2, maximumFractionDigits: 2}).format(amount);
-            // Currencies commonly used after the amount
-            const postfixCurrencies = new Set(['kr', 'kr.', 'Fr', 'zł']);
-            if (postfixCurrencies.has(currencySymbol)) {
-                return `${formattedAmount} ${currencySymbol}`;
+
+            // check zero decimal currencies
+            let zeroDecimalCurrencies = new Set(['jpy', 'vnd', '₫', 'idr']);
+            if (zeroDecimalCurrencies.has(currency)) {
+                formattedAmount = new Intl.NumberFormat('en-US', {maximumFractionDigits: 0}).format(amount);
             }
-            return `${currencySymbol} ${formattedAmount}`;
+
+            // Currencies commonly used after the amount
+            const postfixCurrencies = new Set(['sek', 'dkk', 'chf', 'pln']);
+            if (postfixCurrencies.has(currency)) {
+                return `${formattedAmount} ${currencySymbols[currency]}`;
+            }
+
+            return `${currencySymbols[currency]} ${formattedAmount}`;
         }
 
         function formatMonth(date) {
@@ -260,7 +299,7 @@
                 categorySelect.innerHTML = config.categories.map(cat => 
                     `<option value="${cat}">${cat}</option>`
                 ).join('');
-                currencySymbol = config.currency;
+                currency = config.currency;
                 startDate = config.startDate;
                 const response = await fetch('/expenses');
                 if (!response.ok) throw new Error('Failed to fetch data');


### PR DESCRIPTION
Non-decimal currencies such as JPY no long display a decimal point.

![1749520610_grim](https://github.com/user-attachments/assets/6adced96-ae22-4909-8b54-618f798941ac)
![1749520587_grim](https://github.com/user-attachments/assets/40f2e21d-7a2c-40b2-8597-78414782938b)

This includes changes for Japanese Yen, South Korean Won, Vietnamese Dong, and Indonesian Rupiah. The web frontend for checks for a list of non-decimal currencies in the formatCurrency function and returns the currency without trailing decimals. This does not change how currencies are represented internally.

To accomplish this, the way currency is determined had to be changed from currency symbol to ISO currency code. This is due to JPY and CNY sharing the same unicode for currency symbol, one containing a decimal and the other not. This by consequence fixes a bug in which, when the currency is set to JPY and the user reloads the settings page, the selected currency appears as CNY. This also allows other dollar currencies to share use of '$' instead of requiring a prefix such as 'C$' or 'M$'.

One potential issue this raises is a user being able to add expenses with decimals in currencies that don't support them. This should be trivial to add a check for, given there is already a check for expenses with more than two figures past the decimal. This would still be able to be bypassed by changing to a decimal currency and adding an expense before changing back to a non-decimal.

There may also be some leftover or redundant variable/code left over from the change in functionality.