### PR TITLE
Allow for negative values in expenses

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,10 @@ If setting up for the first time, an environment variable can be used for ease. 
 CURRENCY=eur ./expenseowl
 ```
 
+> [!NOTE]
+> Expense Owl started off by onlying allowing positive values but now allows for negative values (see https://github.com/Tanq16/ExpenseOwl/pull/39). Positive values as an expense will indicate money going out, while negative values can be used to indicate a return or reimbursment of an expense (money coming back in).
+> This project undestands that this choice is subjective so we hope to introduce more functionality to configure this. 
+
 ExpenseOwl also supports custom categories. A default set is pre-loaded in the config for ease of use and can be easily changed within the UI.
 
 Like currency, if setting up for the first time, categories can be specified in an environment variable like so:

--- a/internal/api/import-export.go
+++ b/internal/api/import-export.go
@@ -163,7 +163,7 @@ func (h *Handler) ImportCSV(w http.ResponseWriter, r *http.Request) {
 		}
 		// Handle amount (skipping regex since parsing as float)
 		amount, err := strconv.ParseFloat(strings.TrimSpace(record[amountIdx]), 64)
-		if err != nil || amount <= 0 {
+		if err != nil {
 			log.Printf("Warning: Skipping row %d due to invalid amount: %s\n", i, record[amountIdx])
 			continue
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -86,9 +86,6 @@ func (e *Expense) Validate() error {
 	if e.Category == "" {
 		return errors.New("category is required")
 	}
-	if e.Amount <= 0 {
-		return errors.New("amount must be greater than 0")
-	}
 	return nil
 }
 

--- a/internal/web/templates/index.html
+++ b/internal/web/templates/index.html
@@ -86,7 +86,7 @@
                 
                 <div class="form-group">
                     <label for="amount">Amount</label>
-                    <input type="number" id="amount" step="0.01" min="0.01" required>
+                    <input type="number" id="amount" step="0.01" required>
                 </div>
                 
                 <div class="form-group">

--- a/internal/web/templates/table.html
+++ b/internal/web/templates/table.html
@@ -49,7 +49,7 @@
                 
                 <div class="form-group">
                     <label for="amount">Amount</label>
-                    <input type="number" id="amount" step="0.01" min="0.01" required>
+                    <input type="number" id="amount" step="0.01" required>
                 </div>
                 
                 <div class="form-group">


### PR DESCRIPTION
This makes it possible to record expenses that can be negative, such as refunds or corrections.

It would not make any changes to existing users or introduce breaking changes.

Negative values are currently allowed by modifying the expenses.json file directly.