### PR TITLE
Add port changing ability

### DIFF
--- a/cmd/expenseowl/main.go
+++ b/cmd/expenseowl/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"flag"
+	"fmt"
 	"log"
 	"net/http"
 
@@ -11,7 +13,7 @@ import (
 
 var version = "dev"
 
-func runServer() {
+func runServer(port int) {
 	storage, err := storage.InitializeStorage()
 	if err != nil {
 		log.Fatalf("Failed to initialize storage: %v", err)
@@ -85,12 +87,14 @@ func runServer() {
 	http.HandleFunc("/import/csv", handler.ImportCSV)
 	http.HandleFunc("/import/csvold", handler.ImportOldCSV)
 
-	log.Println("Starting server on port 8080...")
-	if err := http.ListenAndServe(":8080", nil); err != nil {
+	log.Println("Starting server on port", port, "...")
+	if err := http.ListenAndServe(fmt.Sprint(":", port), nil); err != nil {
 		log.Fatalf("Server failed to start: %v", err)
 	}
 }
 
 func main() {
-	runServer()
+	port := flag.Int("port", 8080, "Port to serve from")
+	flag.Parse()
+	runServer(*port)
 }


### PR DESCRIPTION
I know this is easily solved within Docker, but since Go makes single self-contained executables, I didn't feel the need to host it in Docker. This means that there's absolutely no way for me to change the port this runs on. I really needed this feature to avoid conflicting with other things on my server.

Simple addition: a flag called "-port" defaults to 8080, so the behavior of the app is not changed unless someone explicitly adds it.