### PR TITLE
Control Settings UI via env flag

### DIFF
--- a/internal/web/templates/index.html
+++ b/internal/web/templates/index.html
@@ -43,9 +43,11 @@
                 <a href="/table" class="view-button" data-tooltip="Table View">
                     <i class="fa-solid fa-table"></i>
                 </a>
+                {{if not .HideSettings}}
                 <a href="/settings" class="view-button" data-tooltip="Settings">
                     <i class="fa-solid fa-gear"></i>
                 </a>
+                {{end}}
             </div>
         </header>
 

--- a/internal/web/templates/settings.html
+++ b/internal/web/templates/settings.html
@@ -30,9 +30,11 @@
                 <a href="/table" class="view-button" data-tooltip="Table View">
                     <i class="fa-solid fa-table"></i>
                 </a>
+                {{if not .HideSettings}}
                 <a href="/settings" class="view-button active" data-tooltip="Settings">
                     <i class="fa-solid fa-gear"></i>
                 </a>
+                {{end}}
             </div>
         </header>
 

--- a/internal/web/templates/table.html
+++ b/internal/web/templates/table.html
@@ -30,9 +30,11 @@
                 <a href="/table" class="view-button active" data-tooltip="Table View">
                     <i class="fa-solid fa-table"></i>
                 </a>
+                {{if not .HideSettings}}
                 <a href="/settings" class="view-button" data-tooltip="Settings">
                     <i class="fa-solid fa-gear"></i>
                 </a>
+                {{end}}
             </div>
         </header>
 


### PR DESCRIPTION
Purpose is to make it simpler for folks so they won't mistakenly make changes to the settings unintentionally. (Useful for when the instance is shared with group of people)

 When HIDE_SETTINGS=true, the settings gear icon will be hidden from the navigation bar on all pages. 

Users can still access /settings directly via URL if needed, but the UI navigation link will not be visible. (The endpoint can still be authenticated via other means)

When the environment variable is not set or set to any other value, the settings link will display normally.

with docker run 

```bash
docker run -e HIDE_SETTINGS=true ...
```

with docker compose

```docker-compose.yml
services:
  app:
    build:
      context: .
      dockerfile: Dockerfile
    ports:
      - "8080:8080"
    restart: unless-stopped
    volumes:
      - data:/app/data
    environment:
      - HIDE_SETTINGS=true

volumes:
  data:
```
